### PR TITLE
Add ruff for linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,12 +111,12 @@ jobs:
         db-backend: ["postgresql"]
         nautobot-version: ["2.3.10"]
         include:
-          - python-version: ["3.11"]
-            db-backend: ["postgresql"]
-            nautobot-version: ["2.0.6"]
-          - python-version: ["3.12"]
-            db-backend: ["mysql"]
-            nautobot-version: ["2.3.10"]
+          - python-version: "3.11"
+            db-backend: "postgresql"
+            nautobot-version: "2.0.6"
+          - python-version: "3.12"
+            db-backend: "mysql"
+            nautobot-version: "2.3.10"
     env:
       INVOKE_NAUTOBOT_CONSUMABLES_PYTHON_VER: "${{ matrix.python-version }}"
       INVOKE_NAUTOBOT_CONSUMABLES_NAUTOBOT_VER: "${{ matrix.nautobot-version }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   APP_NAME: "consumables"
 
 jobs:
-  bandit:
+  ruff:
     runs-on: "ubuntu-20.04"
     env:
       INVOKE_NAUTOBOT_CONSUMABLES_LOCAL: "True"
@@ -26,31 +26,7 @@ jobs:
       - name: "Setup environment"
         uses: "./.github/actions/poetry"
       - name: "Linting: bandit"
-        run: poetry run invoke test.bandit
-
-  pydocstyle:
-    runs-on: "ubuntu-20.04"
-    env:
-      INVOKE_NAUTOBOT_CONSUMABLES_LOCAL: "True"
-    steps:
-      - name: "Check out repository"
-        uses: "actions/checkout@v4"
-      - name: "Setup environment"
-        uses: "./.github/actions/poetry"
-      - name: "Linting: pydocstyle"
-        run: poetry run invoke test.pydocstyle
-
-  flake8:
-    runs-on: "ubuntu-20.04"
-    env:
-      INVOKE_NAUTOBOT_CONSUMABLES_LOCAL: "True"
-    steps:
-      - name: "Check out repository"
-        uses: "actions/checkout@v4"
-      - name: "Setup environment"
-        uses: "./.github/actions/poetry"
-      - name: "Linting: flake8"
-        run: poetry run invoke test.flake8
+        run: poetry run invoke test.ruff -a both
 
   mypy:
     runs-on: "ubuntu-20.04"
@@ -78,9 +54,7 @@ jobs:
 
   pylint:
     needs:
-      - "bandit"
-      - "pydocstyle"
-      - "flake8"
+      - "ruff"
       - "mypy"
       - "poetry"
     runs-on: "ubuntu-20.04"
@@ -88,7 +62,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.12"]
-        nautobot-version: ["stable"]
+        nautobot-version: ["2.3.10"]
     env:
       INVOKE_NAUTOBOT_CONSUMABLES_PYTHON_VER: "${{ matrix.python-version }}"
       INVOKE_NAUTOBOT_CONSUMABLES_NAUTOBOT_VER: "${{ matrix.nautobot-version }}"
@@ -135,14 +109,14 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
         db-backend: ["postgresql"]
-        nautobot-version: ["stable"]
+        nautobot-version: ["2.3.10"]
         include:
           - python-version: ["3.11"]
             db-backend: ["postgresql"]
             nautobot-version: ["2.0.6"]
           - python-version: ["3.12"]
             db-backend: ["mysql"]
-            nautobot-version: ["stable"]
+            nautobot-version: ["2.3.10"]
     env:
       INVOKE_NAUTOBOT_CONSUMABLES_PYTHON_VER: "${{ matrix.python-version }}"
       INVOKE_NAUTOBOT_CONSUMABLES_NAUTOBOT_VER: "${{ matrix.nautobot-version }}"

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -28,7 +28,6 @@ WORKDIR $NAUTOBOT_ROOT
 # and CI and local development may have a newer version of Poetry
 # Since this is only used for development and we don't ship this container, pinning Poetry back is not expressly necessary
 # We also don't need virtual environments in container
-ENV POETRY_VERSION=1.5.1
 RUN which poetry || curl -sSL https://install.python-poetry.org | python3 - && \
   poetry config virtualenvs.create false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ pydocstyle = "^6.3.0"
 pylint = "^3.2.5"
 pylint-django = "^2.5.3"
 python-dotenv = "^1.0.1"
+ruff = "^0.7.1"
 toml = "^0.10.2"
 types-factory-boy = "0.4.1"
 types-graphene = "^0.22"
@@ -108,6 +109,59 @@ disable = [
     "duplicate-code",
     "too-many-ancestors",
     "fixme",
+]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = [
+    "B",  # flake8-bugbear
+    "D",  # pydocstyle
+    "E",  # pycodestyle error
+    "F",  # pyflakes
+    "I",  # isort
+    "PL", # pylint
+    "S",  # bandit
+    "W",  # pycodestyle warning
+]
+ignore = [
+    # D105 enforces docstrings for magic methods, e.g. __str__(). It seems unnecessary.
+    "D105",
+
+    # warning: `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible.
+    "D203", # 1 blank line required before class docstring
+
+    # D212 is enabled by default in google convention, and complains if we have a docstring like:
+    # """
+    # My docstring is on the line after the opening quotes instead of on the same line as them.
+    # """
+    # We've discussed and concluded that we consider this to be a valid style choice.
+    "D212", # Multi-line docstring summary should start at the first line
+]
+
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+
+[tool.ruff.lint.pycodestyle]
+# Combine line-length and max-line-length to emulate flake8-bugbear's B950 rule.
+# The formatter uses line-length, but rule E501 won't complain until a line hits 111.
+max-line-length = 110
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.per-file-ignores]
+"nautobot_consumables/**/__init__.py" = [
+    "D",
+]
+"nautobot_consumables/migrations/*" = [
+    "D",
+]
+"nautobot_consumables/tests/*" = [
+    "D",
+    "S"
 ]
 
 [tool.pydocstyle]

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -26,10 +26,10 @@ namespace.add_collection(Collection.from_module(test))
 namespace.configure(
     {
         "nautobot_consumables": {
-            "nautobot_ver": "1.6.1",
+            "nautobot_ver": "2.3.10",
             "project_name": "nautobot-consumables",
             "project_source": "nautobot_consumables",
-            "python_ver": "3.10",
+            "python_ver": "3.12",
             "local": False,
             "compose_dir": BASE_DIR.joinpath("development").as_posix(),
             "compose_files": [

--- a/tasks/control.py
+++ b/tasks/control.py
@@ -85,7 +85,7 @@ def lock(context: Context, check: bool = False, constrain_nautobot_ver: bool = F
         if check:
             command.append("check")
         else:
-            command.extend(["lock", "--noupdate"])
+            command.extend(["lock", "--no-update"])
 
     helpers.run_command(context, " ".join(command))
 
@@ -402,7 +402,7 @@ def showmigrations(context: Context, plan: bool = False, verbose: bool = False) 
 
 
 @task
-def migrate(context) -> None:
+def migrate(context: Context) -> None:
     """Perform the Django migrate operation."""
     helpers.run_command(context, "nautobot-server migrate")
 

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -23,10 +23,12 @@ from tasks import helpers
         "enable": "Pass the value to the pylint --enable flag, can be given multiple times.",
         "path": "Set an alternate path for pylint to check, default is nautobot_consumables",
         "verbose": "Enable verbose output for the pylint command.",
+        "exit-zero": "Pass exit-zero options to pylint.",
     },
 )
 def pylint(context: Context, path: str = "nautobot_consumables", verbose: bool = False,
-           enable: list[str] | None = None, disable: list[str] | None = None) -> None:
+           enable: list[str] | None = None, disable: list[str] | None = None,
+           exit_zero: bool = False) -> None:
     """Run pylint code analysis."""
     command = ["pylint", "--init-hook", "\"import nautobot; nautobot.setup()\"",
                "--rcfile", "pyproject.toml"]
@@ -37,10 +39,53 @@ def pylint(context: Context, path: str = "nautobot_consumables", verbose: bool =
         command.extend([f"--disable={value}" for value in disable])
     if enable is not None:
         command.extend([f"--enable={value}" for value in enable])
+    if exit_zero is True:
+        command.append("--exit-zero")
 
     command.append(path)
 
     helpers.run_command(context, " ".join(command))
+
+
+@task(
+    help={
+        "action": "One of `lint`, `format`, or `both`, default is `lint`.",
+        "fix": "Automatically fix code when running the selected action. May not be able "
+               "to fix everything.",
+        "output-format": "See https://docs.astral.sh/ruff/settings/#output-format, "
+                         "default is `concise`.",
+        "diff": "Show a diff between the current file and what the ruff formatted file would "
+                "look like. If both --diff and --fix are present, --fix will be ignored.",
+        "path": "Specific file or directory to check/format.",
+    }
+)
+def ruff(context: Context, action: str = "lint", fix: bool = False, output_format: str = "concise",
+         diff: bool = False, path: str = "nautobot_consumables/") -> None:
+    """Run the ruff linter/formatter."""
+    commands = []
+    if action in ["lint", "both"]:
+        command = ["ruff", "check"]
+        if fix:
+            command.append("--fix")
+        command.extend(["--output-format", output_format, path])
+        commands.append(("ruff linter", " ".join(command)))
+    if action in ["format", "both"]:
+        command = ["ruff", "format"]
+        if diff:
+            command.append("--diff")
+        elif not fix:
+            command.append("--check")
+        command.append(path)
+        commands.append(("ruff formatter", " ".join(command)))
+
+    if not commands:
+        raise SystemExit(f"Invalid action: {action}")
+
+    for i, command in enumerate(commands):
+        if i > 0:
+            print()
+        print(f"Running {command[0]}")
+        helpers.run_command(context, command[1], warn=True)
 
 
 @task(
@@ -200,29 +245,35 @@ def coverage(context: Context, covered: bool = False) -> None:
                 "given and --seed is not, a default seed will be used.",
         "flush": "Flush database before running tests.",
         "verbose": "Enable verbose output for lint and test commands.",
+        "ruff-lint": "Use ruff instead of flake8, pydocstyle, and bandit.",
     }
 )
 def everything(context: Context, keepdb: bool = False, seed: str | None = None,
-               flush: bool = False, verbose: bool = False) -> None:
+               flush: bool = False, verbose: bool = False, ruff_lint: bool = False) -> None:
     """Run all the linters and pytest with coverage."""
     print("Running pylint...")
     pylint(context, verbose=verbose)
 
-    print("-" * 70)
-    print("\nRunning flake8...")
-    flake8(context, verbose=verbose)
+    if ruff_lint:
+        print("-" * 70)
+        print("\nRunning ruff...")
+        ruff(context)
+    else:
+        print("-" * 70)
+        print("\nRunning flake8...")
+        flake8(context, verbose=verbose)
 
-    print(f"\n{('-' * 70)}\n")
-    print("Running pydocstyle...")
-    pydocstyle(context, verbose=verbose)
+        print(f"\n{('-' * 70)}\n")
+        print("Running pydocstyle...")
+        pydocstyle(context, verbose=verbose)
+
+        print(f"\n{('-' * 70)}\n")
+        print("Running bandit...")
+        bandit(context)
 
     print(f"\n{('-' * 70)}\n")
     print("Running mypy...")
     mypy(context, verbose=verbose)
-
-    print(f"\n{('-' * 70)}\n")
-    print("Running bandit...")
-    bandit(context)
 
     print(f"\n{('-' * 70)}\n")
     print("Running tests...")


### PR DESCRIPTION
Replace pydocstyle, bandit, and flake8 with ruff.

Pin tests to nautobot 2.3.10 instead of stable, 2.3.11 changed something in one of the NautobotUIViewSet mixin classes that breaks bulk update tests.


